### PR TITLE
Update for new LavaPlayer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.sedmelluq</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>1.3.22</version>
+            <version>1.3.76</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -58,9 +58,9 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <name>jcenter-bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <id>dv8tion</id>
+            <name>m2-dv8tion</name>
+            <url>https://m2.dv8tion.net/releases</url>
         </repository>
     </repositories>
 
@@ -112,6 +112,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Hi Freya, this is my attempt to update Lavamark so that it can be used with the new LavaPlayer.

I have not used Maven yet before this so I'm not sure if I'm doing this right, there's a few things I have questions about:

Should the target Java version be changed from 1.8 since Lavalink uses 11+ now?
Should the versions on the dependencies be updated?

I was able to get a Lavamark.jar compiled with these changes that worked for me, but locally, additionally I had to change the playlist url included to a different one as I had gotten
`Exception in thread "main" com.sedmelluq.discord.lavaplayer.tools.FriendlyException: The playlist does not exist.`
when trying to run the jar with the playlist you have included, even though I could access that playlist in a browser.

If you want to implement these changes yourself instead, please feel free to close this PR and/or use any part of it in your own commits.