### PR TITLE
Update Lavaplayer, QoL improvements.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ github.ref }}
           body: Automatic release.
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+on:
+  push:
+    tags:
+      - '*'
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          java-package: 'jdk'
+          cache: maven
+      - name: Build
+        run: mvn clean package
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: Automatic release.
+          draft: false
+          prerelease: false
+      - name: Upload Artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/lavamark.jar
+          asset_name: lavamark.jar
+          asset_content_type: application/java-archive

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ java -jar lavamark-1.0.jar
 
 ## Lavamark Options
 You can specify any of the following options as a command-line argument when launching Lavamark.
+Application options are specified after the JAR name.
 
 | Option           | Description                                                                                |
 |------------------|--------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ java -jar lavamark-1.0.jar
 You can specify any of the following options as a command-line argument when launching Lavamark.
 Application options are specified after the JAR name.
 
-| Option           | Description                                                                                |
-|------------------|--------------------------------------------------------------------------------------------|
-| `h`/`help`       | Displays Lavamark's available options.                                                     |
-| `i`/`identifier` | The identifier/URL of the track/playlist to use for the test.                              |
-| `b`/`block`      | The IPv6 block to use for rotation, specified as CIDR notation.                            |
-| `s`/`step`       | The number of players to spawn after a fixed interval. Be careful when using large values. |
-| `t`/`transcode`  | Simulate a load by forcing transcoding.                                                    |
+| Option              | Description                                                                                        |
+|---------------------|----------------------------------------------------------------------------------------------------|
+| `-h`/`--help`       | Displays Lavamark's available options.                                                             |
+| `-i`/`--identifier` | The identifier or URL of the track/playlist to use for the benchmark.                              |
+| `-b`/`--block`      | The IPv6 block to use for rotation, specified as CIDR notation. Only applies to YouTube currently. |
+| `-s`/`--step`       | The number of players to spawn after two seconds. Be careful when using large values.              |
+| `-t`/`--transcode`  | Simulate a load by forcing transcoding.                                                            |

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Lavaplayer server benchmarker. How many lavaplayer tracks can your server handle
 ```
 java -jar lavamark-1.0.jar
 ```
+
+## Lavamark Options
+You can specify any of the following options as a command-line argument when launching Lavamark.
+
+| Option           | Description                                                                                |
+|------------------|--------------------------------------------------------------------------------------------|
+| `h`/`help`       | Displays Lavamark's available options.                                                     |
+| `i`/`identifier` | The identifier/URL of the track/playlist to use for the test.                              |
+| `b`/`block`      | The IPv6 block to use for rotation, specified as CIDR notation.                            |
+| `s`/`step`       | The number of players to spawn after a fixed interval. Be careful when using large values. |

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ You can specify any of the following options as a command-line argument when lau
 | `i`/`identifier` | The identifier/URL of the track/playlist to use for the test.                              |
 | `b`/`block`      | The IPv6 block to use for rotation, specified as CIDR notation.                            |
 | `s`/`step`       | The number of players to spawn after a fixed interval. Be careful when using large values. |
+| `t`/`transcode`  | Simulate a load by forcing transcoding.                                                    |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Lavamark
 Lavaplayer server benchmarker. How many lavaplayer tracks can your server handle playing at once?
 
-[Download](https://ci.fredboat.com/viewType.html?buildTypeId=Public_Lavamark_Build&guest=1)
+[Download](../../releases)
 
 ## Usage
 ```
-java -jar lavamark-1.0.jar
+java -jar lavamark.jar
 ```
 
 ## Lavamark Options

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.sedmelluq</groupId>
+            <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>1.3.76</version>
+            <version>1.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.arbjerg</groupId>
+            <artifactId>lavaplayer-ext-youtube-rotator</artifactId>
+            <version>1.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -54,6 +59,11 @@
             <artifactId>logback-classic</artifactId>
             <version>1.2.13</version>
         </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.6.0</version>
+        </dependency>
     </dependencies>
 
     <repositories>
@@ -61,6 +71,15 @@
             <id>dv8tion</id>
             <name>m2-dv8tion</name>
             <url>https://m2.dv8tion.net/releases</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <name>bintray</name>
+            <url>https://jcenter.bintray.com</url>
+        </repository>
+        <repository>
+            <id>jitpack</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,6 @@
             <url>https://m2.dv8tion.net/releases</url>
         </repository>
         <repository>
-            <id>central</id>
-            <name>bintray</name>
-            <url>https://jcenter.bintray.com</url>
-        </repository>
-        <repository>
             <id>jitpack</id>
             <url>https://jitpack.io</url>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,17 @@
         <dependency>
             <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>1.5.3</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer-ext-youtube-rotator</artifactId>
-            <version>1.5.3</version>
+            <version>2.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.lavalink.youtube</groupId>
+            <artifactId>common</artifactId>
+            <version>1.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -71,6 +76,11 @@
             <id>dv8tion</id>
             <name>m2-dv8tion</name>
             <url>https://m2.dv8tion.net/releases</url>
+        </repository>
+        <repository>
+            <id>lavalink</id>
+            <name>maven-lavalink</name>
+            <url>https://maven.lavalink.dev/releases</url>
         </repository>
         <repository>
             <id>jitpack</id>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <finalName>lavamark</finalName>
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">

--- a/src/main/java/com/frederikam/lavamark/AudioConsumer.java
+++ b/src/main/java/com/frederikam/lavamark/AudioConsumer.java
@@ -50,7 +50,6 @@ public class AudioConsumer extends Thread {
         long start = System.currentTimeMillis();
         long i = 0;
 
-        //noinspection InfiniteLoopStatement
         while (running) {
 
             if (player.canProvide()) {

--- a/src/main/java/com/frederikam/lavamark/Lavamark.java
+++ b/src/main/java/com/frederikam/lavamark/Lavamark.java
@@ -24,6 +24,7 @@
 
 package com.frederikam.lavamark;
 
+import com.sedmelluq.discord.lavaplayer.natives.ConnectorNativeLibLoader;
 import com.sedmelluq.discord.lavaplayer.player.AudioConfiguration;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
@@ -90,6 +91,12 @@ public class Lavamark {
             return;
         }
 
+        boolean transcode = parsed.hasOption("transcode");
+
+        if (transcode) {
+            ConnectorNativeLibLoader.loadConnectorLibrary();
+        }
+
         if (parsed.hasOption("block")) {
             String ipBlock = parsed.getOptionValue("block");
 
@@ -115,7 +122,7 @@ public class Lavamark {
         }
 
         try {
-            doLoop(stepSize, parsed.hasOption("transcode"));
+            doLoop(stepSize, transcode);
         } catch (Exception e) {
             log.error("Benchmark ended due to exception!");
             throw new RuntimeException(e);

--- a/src/main/java/com/frederikam/lavamark/Lavamark.java
+++ b/src/main/java/com/frederikam/lavamark/Lavamark.java
@@ -62,9 +62,6 @@ public class Lavamark {
         PLAYER_MANAGER.getConfiguration().setResamplingQuality(AudioConfiguration.ResamplingQuality.LOW);
         AudioSourceManagers.registerRemoteSources(PLAYER_MANAGER);
 
-        String jarPath = Lavamark.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-        String jarName = jarPath.substring(jarPath.lastIndexOf("/") + 1);
-
         Options options = new Options()
             .addOption("b", "block", true, "The IPv6 block to use for rotation. This must be specified as CIDR notation.")
             .addOption("s", "step", true, "The number of players to spawn after a fixed interval. Be careful when using large values.")
@@ -79,12 +76,12 @@ public class Lavamark {
         try {
             parsed = parser.parse(options, args);
         } catch (ParseException parseException) {
-            formatter.printHelp("java -jar " + jarName, options);
+            formatter.printHelp("", options);
             return;
         }
 
         if (parsed.hasOption("help")) {
-            formatter.printHelp("java -jar " + jarName, options);
+            formatter.printHelp("", options);
             return;
         }
 

--- a/src/main/java/com/frederikam/lavamark/Lavamark.java
+++ b/src/main/java/com/frederikam/lavamark/Lavamark.java
@@ -28,10 +28,16 @@ import com.sedmelluq.discord.lavaplayer.player.AudioConfiguration;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
+import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.lava.extensions.youtuberotator.YoutubeIpRotatorSetup;
+import com.sedmelluq.lava.extensions.youtuberotator.planner.RotatingNanoIpRoutePlanner;
+import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv6Block;
+import org.apache.commons.cli.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -40,7 +46,6 @@ public class Lavamark {
     private static final Logger log = LoggerFactory.getLogger(Lavamark.class);
 
     static final AudioPlayerManager PLAYER_MANAGER = new DefaultAudioPlayerManager();
-    private static final String DEFAULT_PLAYLIST = "https://www.youtube.com/watch?v=7v154aLVo70&list=LLqqLoSLryroL7b7TAL8gfhQ&index=22";
     private static final String DEFAULT_OPUS = "https://www.youtube.com/watch?v=M_36UBLkni8";
     private static final long INTERVAL = 2 * 1000;
     private static final long STEP_SIZE = 20;
@@ -57,20 +62,58 @@ public class Lavamark {
         PLAYER_MANAGER.getConfiguration().setResamplingQuality(AudioConfiguration.ResamplingQuality.LOW);
         AudioSourceManagers.registerRemoteSources(PLAYER_MANAGER);
 
-        log.info("Loading AudioTracks");
+        String jarPath = Lavamark.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        String jarName = jarPath.substring(jarPath.lastIndexOf("/") + 1);
 
-        String identifier;
-        if (args.length >= 1 && args[0].equals("opus")) {
-            identifier = DEFAULT_OPUS;
-        } else {
-            identifier = DEFAULT_PLAYLIST;
+        Options options = new Options()
+            .addOption("b", "block", true, "The IPv6 block to use for rotation. This must be specified as CIDR notation.")
+            .addOption("s", "step", true, "The number of players to spawn after a fixed interval. Be careful when using large values.")
+            .addOption("i", "identifier", true, "The audio identifier to use for the test. Must be a URL pointing to a supported audio source.")
+            .addOption("h", "help", false, "Displays the supported command line arguments.");
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+
+        CommandLine parsed;
+
+        try {
+            parsed = parser.parse(options, args);
+        } catch (ParseException parseException) {
+            formatter.printHelp("java -jar " + jarName, options);
+            return;
         }
+
+        if (parsed.hasOption("help")) {
+            formatter.printHelp("java -jar " + jarName, options);
+            return;
+        }
+
+        if (parsed.hasOption("block")) {
+            String ipBlock = parsed.getOptionValue("block");
+
+            YoutubeAudioSourceManager ytasm = PLAYER_MANAGER.source(YoutubeAudioSourceManager.class);
+            RotatingNanoIpRoutePlanner planner = new RotatingNanoIpRoutePlanner(Collections.singletonList(new Ipv6Block(ipBlock)));
+            new YoutubeIpRotatorSetup(planner).forSource(ytasm).setup();
+
+            log.info("IP rotation configured.");
+        }
+
+        String identifier = parsed.getOptionValue("identifier", DEFAULT_OPUS);
+
+        log.info("Loading AudioTracks from identifier {}", identifier);
 
         tracks = new PlaylistLoader().loadTracksSync(identifier);
         log.info(tracks.size() + " tracks loaded. Beginning benchmark...");
 
+        long stepSize = STEP_SIZE;
+
+        if (parsed.hasOption("step")) {
+            stepSize = Long.getLong(parsed.getOptionValue("step"));
+            log.info("Step set to {} players every {} milliseconds.", stepSize, INTERVAL);
+        }
+
         try {
-            doLoop();
+            doLoop(stepSize);
         } catch (Exception e) {
             log.error("Benchmark ended due to exception!");
             throw new RuntimeException(e);
@@ -79,10 +122,10 @@ public class Lavamark {
         System.exit(0);
     }
 
-    private static void doLoop() throws InterruptedException {
+    private static void doLoop(long stepSize) throws InterruptedException {
         //noinspection InfiniteLoopStatement
         while (true) {
-            spawnPlayers();
+            spawnPlayers(stepSize);
 
             AudioConsumer.Results results = AudioConsumer.getResults();
             log.info("Players: " + players.size() + ", Null frames: " + results.getLossPercentString());
@@ -98,8 +141,8 @@ public class Lavamark {
         }
     }
 
-    private static void spawnPlayers() {
-        for (int i = 0; i < STEP_SIZE; i++) {
+    private static void spawnPlayers(long stepSize) {
+        for (int i = 0; i < stepSize; i++) {
             players.add(new Player());
         }
     }

--- a/src/main/java/com/frederikam/lavamark/Lavamark.java
+++ b/src/main/java/com/frederikam/lavamark/Lavamark.java
@@ -63,7 +63,7 @@ public class Lavamark {
         AudioSourceManagers.registerRemoteSources(PLAYER_MANAGER);
 
         Options options = new Options()
-            .addOption("b", "block", true, "The IPv6 block to use for rotation. This must be specified as CIDR notation.")
+            .addOption("b", "block", true, "The IPv6 block to use for rotation (YouTube only). This must be specified as CIDR notation.")
             .addOption("s", "step", true, "The number of players to spawn after a fixed interval. Be careful when using large values.")
             .addOption("i", "identifier", true, "The audio identifier to use for the test. Must be a URL pointing to a supported audio source.")
             .addOption("h", "help", false, "Displays the supported command line arguments.");

--- a/src/main/java/com/frederikam/lavamark/Lavamark.java
+++ b/src/main/java/com/frederikam/lavamark/Lavamark.java
@@ -68,11 +68,11 @@ public class Lavamark {
         String jarName = jarPath.substring(jarPath.lastIndexOf("/") + 1);
 
         Options options = new Options()
-            .addOption("b", "block", true, "The IPv6 block to use for rotation (YouTube only). This must be specified as CIDR notation.")
-            .addOption("s", "step", true, "The number of players to spawn after a fixed interval. Be careful when using large values.")
-            .addOption("i", "identifier", true, "The audio identifier to use for the test. Must be a URL pointing to a supported audio source.")
+            .addOption("b", "block", true, "The IPv6 block to use for rotation, specified as CIDR notation. Only applies to YouTube currently.")
+            .addOption("s", "step", true, "The number of players to spawn after two seconds. Be careful when using large values.")
+            .addOption("i", "identifier", true, "The identifier or URL of the track/playlist to use for the benchmark.")
             .addOption("t", "transcode", false, "Simulate a load by forcing transcoding.")
-            .addOption("h", "help", false, "Displays the supported command line arguments.");
+            .addOption("h", "help", false, "Displays Lavamark's available options.");
 
         CommandLineParser parser = new DefaultParser();
         HelpFormatter formatter = new HelpFormatter();

--- a/src/main/java/com/frederikam/lavamark/Player.java
+++ b/src/main/java/com/frederikam/lavamark/Player.java
@@ -13,9 +13,13 @@ public class Player extends AudioEventAdapter {
     private static final Logger log = LoggerFactory.getLogger(Player.class);
     private AudioPlayer player = Lavamark.PLAYER_MANAGER.createPlayer();
 
-    Player() {
+    Player(boolean transcode) {
         player.addListener(this);
         player.playTrack(Lavamark.getTrack());
+
+        if (transcode) {
+            player.setVolume(99);
+        }
 
         AudioConsumer consumer = new AudioConsumer(this);
         consumer.start();


### PR DESCRIPTION
- Bump Lavaplayer to 1.5.3

- Add command-line options for changing step size, audio track identifier and IPv6 block for rotation.
  - Step size has been added as a means of allowing Lavamark to perform tests quicker for more powerful hardware that can handle tens of thousands of players.

  - Audio track identifier was introduced as a means of testing with a variety of sources, such as YouTube (where the format is predominantly Opus), Soundcloud (HLS Opus and mp3 formats), or even HTTP (for testing a wider variety of audio formats) to get a more thorough insight into how hardware performs under various conditions.

  - For higher-specced servers that can handle a lot of players, it's not uncommon for the single IP address used for requests to get banned. This should allow users to carry out full tests without any interruption from blocks.

The default playlist was removed as it no longer exists.